### PR TITLE
refactor: only compile mimalloc on linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ bindgen = "0.69.4"
 http = "1.1.0"
 bytes = "1.6.0"
 http-body-util = "0.1.2"
-mimalloc = "0.1.43"
 
 nalgebra = "0.33.0"
 v = "0.1.0"
@@ -38,6 +37,8 @@ uuid = "1.10.0"
 env_logger = "0.11.5"
 chrono = "0.4.38"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+mimalloc = "0.1.43"
 
 [[bin]]
 name = "horizon"

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@
 // Use the mimalloc allocator, which boasts excellent performance //
 // across a variety of tasks, while being small (8k LOC)          //
 ////////////////////////////////////////////////////////////////////
+#[cfg(target_os = "linux")]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 


### PR DESCRIPTION
# Description

Don't compile mimalloc unless you are on Linux

## Issue(s) Solved 
should fix a problem when compiling for windows or macos. mimalloc seems to fail to compile.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
